### PR TITLE
Photo file path recognition issue fixed

### DIFF
--- a/VacationApp/VacationApp/April_21_2025
+++ b/VacationApp/VacationApp/April_21_2025
@@ -1,0 +1,6 @@
+Daily Summary for April 21, 2025:
+
+- 1 expense recorded ($185.92 USD)
+
+Timeline:
+00:00 - Expense: 135.72 GBP - Accommodation - Hotel stay in Belfast

--- a/VacationApp/VacationApp/FileHelper.cs
+++ b/VacationApp/VacationApp/FileHelper.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+
+namespace VacationApp
+{
+    public static class FileHelper
+    {
+        // method to try multiple path formats
+        public static bool TryFindFile(string filePath, out string validPath)
+        {
+            validPath = filePath;
+
+            // try original path
+            if (File.Exists(filePath))
+            {
+                return true;
+            }
+
+            // try fixing common issues with quotes and whitespace
+            string trimmedPath = filePath.Trim('"', ' ');
+            if (File.Exists(trimmedPath))
+            {
+                validPath = trimmedPath;
+                return true;
+            }
+
+            // try replacing backslashes with forward slashes
+            string forwardSlashPath = filePath.Replace('\\', '/');
+            if (File.Exists(forwardSlashPath))
+            {
+                validPath = forwardSlashPath;
+                return true;
+            }
+
+            // try replacing double backslashes with single
+            string fixedBackslashPath = filePath.Replace("\\\\", "\\");
+            if (File.Exists(fixedBackslashPath))
+            {
+                validPath = fixedBackslashPath;
+                return true;
+            }
+
+            // try to check if it's just a filename in the current directory
+            string currentDirPath = Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileName(filePath));
+            if (File.Exists(currentDirPath))
+            {
+                validPath = currentDirPath;
+                return true;
+            }
+
+            // file not found with any attempt
+            return false;
+        }
+    }
+}

--- a/VacationApp/VacationApp/PhotoService.cs
+++ b/VacationApp/VacationApp/PhotoService.cs
@@ -21,8 +21,18 @@ namespace VacationApp.Photos
         //extract photo metadata
         public void ExtractMetadata()
         {
-            if(File.Exists(FilePath))
+            //try to find the file using helper 
+            string validPath;
+            bool fileExists = FileHelper.TryFindFile(FilePath, out validPath);
+
+            if(fileExists)
             {
+                //update path if it was corrected
+                if(validPath != FilePath)
+                {
+                    FilePath = validPath;
+                }
+
                 try
                 {
                     //read photo metadata and separate categories into groups
@@ -51,7 +61,12 @@ namespace VacationApp.Photos
                     CaptureDate = fileInfo.CreationTime;
                 }
             }
-        }
+            
+            else
+            {
+                CaptureDate = DateTime.Now;
+            }
+        }        
     }
 
     //class to handle photo operations

--- a/VacationApp/VacationApp/PhotoServiceUI.cs
+++ b/VacationApp/VacationApp/PhotoServiceUI.cs
@@ -316,23 +316,30 @@ namespace VacationApp.UI
                 Console.ReadKey();
                 return;
             }
-            
-            // verify file path
-            if (!File.Exists(filePath))
+
+            string validPath;
+            bool fileFound = FileHelper.TryFindFile(filePath, out validPath);
+
+            //show message if filepath needed help
+            if (fileFound && validPath != filePath)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine($"\nFile found at: {validPath}");
+                Console.ResetColor();
+                filePath = validPath; //use fixed filepath
+            }
+
+            //if file wasn't found
+            else if(!fileFound)
             {
                 Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.WriteLine("\nWarning: File does not exist at the specified path.");
+                Console.WriteLine("\nFile does not exist at the specified path.");
                 Console.ResetColor();
-                Console.Write("Do you want to continue anyway? (Y/N): ");
-                
-                if (Console.ReadLine()?.ToUpper() != "Y")
-                {
-                    Console.WriteLine("Operation cancelled. Press any key to continue...");
-                    Console.ReadKey();
-                    return;
-                }
+                Console.WriteLine("Operation cancelled. Press any key to continue...");
+                Console.ReadKey();
+                return;
             }
-            
+                      
             // add the photo
             var photo = photoManager.AddPhoto(tripId, filePath);
             

--- a/VacationApp/VacationApp/settings.json
+++ b/VacationApp/VacationApp/settings.json
@@ -1,6 +1,6 @@
 {
   "DefaultCurrency": "USD",
   "AutoSave": true,
-  "DataSavePath": "/workspaces/CS690-VacationApp/VacationApp/VacationApp/data/",
+  "DataSavePath": "./data/",
   "CustomSettings": {}
 }

--- a/VacationApp/VacationApp/vacation_log_20250418.txt
+++ b/VacationApp/VacationApp/vacation_log_20250418.txt
@@ -1,9 +1,0 @@
-Daily Summary for April 18, 2025:
-
-- 2 expenses recorded ($110.79 USD)
-- 1 note created
-
-Timeline:
-00:00 - Expense: 45.89 GBP - Transportation - Ferry ride from Northern Ireland to Scotland
-00:00 - Expense: 34.99 GBP - Food - Lunch before taking ferry to Scotland.
-22:52 - Note: Ferry


### PR DESCRIPTION
* Fixed issue with file path recognition when user tries extracting photo metadata
* Removed option for user to continue anyway when a file's path is not recognized
* Added `Helper` class to check/fix file paths so that photo files may be located
* Updated PhotoService.cs & PhotoServiceUI.cs to reflect changes